### PR TITLE
cp/bug/gap-between-nav-product

### DIFF
--- a/src/app/components/ProductsCallout.tsx
+++ b/src/app/components/ProductsCallout.tsx
@@ -54,7 +54,7 @@ const ProductsCallout: React.FC<ProductsCalloutProps> = ({ variant = "single", f
             </section>
         )}
         { variant === 'double' && (
-            <section className="flex flex-col gap-12 justify-center items-center h-[564px] md:h-[622px] mt-4 md:mt-0 overflow-hidden bg-products-hero bg-cover bg-right">
+            <section className="flex flex-col gap-12 justify-center items-center h-[564px] md:h-[622px] overflow-hidden bg-products-hero bg-cover bg-right">
             <div className="flex flex-col w-[342px] md:w-[674px] justify-center items-center gap-8">
                 {common}
                 <div className="flex flex-col md:flex-row justify-center items-center gap-6">


### PR DESCRIPTION
### Description 💻

Resolves: #136 

### Implementation 💡

fixes gap between nav and product header on mobile view
[comps](https://www.figma.com/design/04vc8B8NFKlryNS0e1h57T/SoFo-Foods?node-id=230-8252&node-type=frame&t=znA73cuVrXnVoD7U-0)

Reference ticket for bug demo

#### Type of change

- [x] Bug fix
- [ ] New feature

### How to test 🔍

- `npm i`
- `npm run dev`
- navigate to `http://localhost:3000/`
- click on Products
- verify gap is gone on mobile view

### Screenshots/Demos 📷
![Screenshot 2024-10-23 at 5 34 53 PM](https://github.com/user-attachments/assets/bca71afc-7b19-4268-870a-befe2b1c6138)


### Checklist ✅

- [x] Changes have been thoroughly tested
- [x] I have looked over the diffs
- [x] I have moved the Github ticket on the board
- [x] I have requested a review of this PR
