### PR TITLE
Cp/bug/brands on products mobile

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -40,7 +40,7 @@ export default function Products() {
         secondButtonRoute="/order"
       />
         {productsSection}
-      <BrandsCallout />
+      <span className="hidden lg:flex"><BrandsCallout /></span>
       <ContactCallout />
       <Footer />
     </div>


### PR DESCRIPTION
### Description 💻

Resolves: #149 

### Implementation 💡

hides brands callout on Products page for small screens
Reference ticket for bug demo

#### Type of change

- [x] Bug fix
- [ ] New feature

### How to test 🔍

- `npm i`
- `npm run dev`
- navigate to `http://localhost:3000/`
- switch to mobile view
- click on Products
- verify brands callout is no longer visible 
- switch to desktop
- verify brands callout is visible

### Screenshots/Demos 📷
<img width="640" alt="Screenshot 2024-10-24 at 5 23 43 PM" src="https://github.com/user-attachments/assets/1d488fd7-0471-46a1-a82f-b8e9988101cd">




### Checklist ✅

- [x] Changes have been thoroughly tested
- [x] I have looked over the diffs
- [x] I have moved the Github ticket on the board
- [x] I have requested a review of this PR
